### PR TITLE
[other] Add supporting gradle plugins.

### DIFF
--- a/build-plugins/conventions/build.gradle.kts
+++ b/build-plugins/conventions/build.gradle.kts
@@ -1,0 +1,40 @@
+plugins {
+    `kotlin-dsl`
+}
+
+dependencies {
+    compileOnly(libs.kotlin.gradle)
+    compileOnly(libs.android.gradle)
+    compileOnly(libs.compose.gradle)
+    compileOnly(libs.ksp.gradle)
+    compileOnly(libs.sqldelight.gradle)
+}
+
+gradlePlugin {
+    plugins {
+        register("multiplatformModule") {
+            id = libs.plugins.multiplatformModule.get().pluginId
+            implementationClass = "io.github.rubenquadros.timetowish.conventions.MultiplatformModulePlugin"
+        }
+
+        register("composeModule") {
+            id = libs.plugins.composeModule.get().pluginId
+            implementationClass = "io.github.rubenquadros.timetowish.conventions.ComposeModulePlugin"
+        }
+
+        register("kspModule") {
+            id = libs.plugins.kspModule.get().pluginId
+            implementationClass = "io.github.rubenquadros.timetowish.conventions.KspModulePlugin"
+        }
+
+        register("dbModule") {
+            id = libs.plugins.dbModule.get().pluginId
+            implementationClass = "io.github.rubenquadros.timetowish.conventions.DatabaseModulePlugin"
+        }
+
+        register("featureModule") {
+            id = libs.plugins.featureModule.get().pluginId
+            implementationClass = "io.github.rubenquadros.timetowish.conventions.FeatureModulePlugin"
+        }
+    }
+}

--- a/build-plugins/conventions/src/main/kotlin/io/github/rubenquadros/timetowish/conventions/ComposeModulePlugin.kt
+++ b/build-plugins/conventions/src/main/kotlin/io/github/rubenquadros/timetowish/conventions/ComposeModulePlugin.kt
@@ -1,0 +1,41 @@
+package io.github.rubenquadros.timetowish.conventions
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.getByType
+import org.jetbrains.compose.ComposeExtension
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
+class ComposeModulePlugin : Plugin<Project> {
+    override fun apply(target: Project): Unit = with(target) {
+        val libs = getCatalog()
+
+        with(plugins) {
+            apply(libs.findPlugin("multiplatformModule").get().get().pluginId)
+            apply(libs.findPlugin("composeMultiplatform").get().get().pluginId)
+            apply(libs.findPlugin("composeCompiler").get().get().pluginId)
+        }
+
+        val compose = extensions.getByType<ComposeExtension>()
+
+        extensions.configure<KotlinMultiplatformExtension> {
+            sourceSets.run {
+                commonMain.dependencies {
+                    implementation(compose.dependencies.runtime)
+                    implementation(compose.dependencies.foundation)
+                    implementation(compose.dependencies.material3)
+                    implementation(compose.dependencies.ui)
+                    implementation(compose.dependencies.components.resources)
+                    implementation(compose.dependencies.components.uiToolingPreview)
+                }
+
+                androidMain.dependencies {
+                    libs.findBundle("androidx.compose").get().get().forEach {
+                        implementation(it)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/build-plugins/conventions/src/main/kotlin/io/github/rubenquadros/timetowish/conventions/DatabaseModulePlugin.kt
+++ b/build-plugins/conventions/src/main/kotlin/io/github/rubenquadros/timetowish/conventions/DatabaseModulePlugin.kt
@@ -1,0 +1,43 @@
+package io.github.rubenquadros.timetowish.conventions
+
+import app.cash.sqldelight.gradle.SqlDelightExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
+class DatabaseModulePlugin : Plugin<Project> {
+
+    override fun apply(target: Project): Unit = with(target) {
+        val libs = getCatalog()
+
+        plugins.apply(libs.findPlugin("sqldelight").get().get().pluginId)
+
+        extensions.configure<KotlinMultiplatformExtension> {
+            sourceSets.run {
+                commonMain.dependencies {
+                    implementation(libs.findLibrary("sqldelight.coroutines").get().get())
+                }
+
+                androidMain.dependencies {
+                    implementation(libs.findLibrary("sqldelight.android").get().get())
+                }
+
+                iosMain.dependencies {
+                    implementation(libs.findLibrary("sqldelight.ios").get().get())
+                }
+            }
+        }
+
+        extensions.configure<SqlDelightExtension> {
+            databases.apply {
+                create("TimeToWishDb") {
+                    packageName.set("io.github.rubenquadros.timetowish.$moduleName")
+                    schemaOutputDirectory.set(file("${rootProject.projectDir}/db-schema"))
+                    generateAsync.set(true)
+
+                }
+            }
+        }
+    }
+}

--- a/build-plugins/conventions/src/main/kotlin/io/github/rubenquadros/timetowish/conventions/FeatureModulePlugin.kt
+++ b/build-plugins/conventions/src/main/kotlin/io/github/rubenquadros/timetowish/conventions/FeatureModulePlugin.kt
@@ -1,0 +1,50 @@
+package io.github.rubenquadros.timetowish.conventions
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
+class FeatureModulePlugin : Plugin<Project> {
+    override fun apply(target: Project): Unit = with(target) {
+        val libs = getCatalog()
+
+        //apply common plugins
+        with(plugins) {
+            apply(libs.findPlugin("composeModule").get().get().pluginId)
+            apply(libs.findPlugin("kotlinxSerialization").get().get().pluginId)
+            apply(libs.findPlugin("kspModule").get().get().pluginId)
+        }
+
+        extensions.configure<KotlinMultiplatformExtension> {
+            sourceSets.run {
+                commonMain.dependencies {
+                    //library
+                    implementation(libs.findLibrary("compose.navigation").get().get())
+                    implementation(libs.findLibrary("compose.material.navigation").get().get())
+                    implementation(libs.findLibrary("compose.lifecycle.viewmodel").get().get())
+                    implementation(libs.findLibrary("koin.core").get().get())
+                    implementation(libs.findLibrary("koin.annotations").get().get())
+                    implementation(libs.findLibrary("koin.compose").get().get())
+                    implementation(libs.findLibrary("koin.compose.viewmodel").get().get())
+                    implementation(libs.findLibrary("koin.compose.viewmodel.navigation").get().get())
+
+                    //bundle
+                    libs.findBundle("ktor").get().get().forEach {
+                        implementation(it)
+                    }
+
+                    //projects
+                    implementation(project(":foundation:core"))
+                    implementation(project(":foundation:design-system"))
+                    implementation(project(":foundation:navigation-routes"))
+                    implementation(project(":shared"))
+                }
+
+                commonMain.configure {
+                    kotlin.srcDirs("build/generated/ksp/metadata/commonMain/kotlin")
+                }
+            }
+        }
+    }
+}

--- a/build-plugins/conventions/src/main/kotlin/io/github/rubenquadros/timetowish/conventions/KspModulePlugin.kt
+++ b/build-plugins/conventions/src/main/kotlin/io/github/rubenquadros/timetowish/conventions/KspModulePlugin.kt
@@ -1,0 +1,42 @@
+package io.github.rubenquadros.timetowish.conventions
+
+import com.google.devtools.ksp.gradle.KspExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+
+class KspModulePlugin : Plugin<Project> {
+    override fun apply(target: Project): Unit = with(target) {
+        val libs = getCatalog()
+
+        plugins.apply(libs.findPlugin("ksp").get().get().pluginId)
+
+        extensions.configure<KspExtension> {
+            arg("KOIN_CONFIG_CHECK","true")
+            arg("KOIN_DEFAULT_MODULE","false")
+            arg("KOIN_USE_COMPOSE_VIEWMODEL","true")
+        }
+
+        dependencies {
+            add("kspCommonMainMetadata", libs.findLibrary("koin.ksp.compiler").get().get())
+        }
+
+        // WORKAROUND: ADD this dependsOn("kspCommonMainKotlinMetadata") instead of above dependencies
+        tasks.withType<KotlinCompilationTask<*>>().configureEach {
+            if (name != "kspCommonMainKotlinMetadata") {
+                dependsOn("kspCommonMainKotlinMetadata")
+            }
+        }
+
+        afterEvaluate {
+            tasks.filter {
+                it.name.contains("SourcesJar", true)
+            }.forEach {
+                it.dependsOn("kspCommonMainKotlinMetadata")
+            }
+        }
+    }
+}

--- a/build-plugins/conventions/src/main/kotlin/io/github/rubenquadros/timetowish/conventions/MultiplatformModulePlugin.kt
+++ b/build-plugins/conventions/src/main/kotlin/io/github/rubenquadros/timetowish/conventions/MultiplatformModulePlugin.kt
@@ -1,0 +1,63 @@
+package io.github.rubenquadros.timetowish.conventions
+
+import com.android.build.gradle.LibraryExtension
+import org.gradle.api.JavaVersion
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
+class MultiplatformModulePlugin : Plugin<Project> {
+    override fun apply(target: Project): Unit = with(target) {
+        val libs = getCatalog()
+
+        with(plugins) {
+            apply(libs.findPlugin("kotlinMultiplatform").get().get().pluginId)
+            apply(libs.findPlugin("androidLibrary").get().get().pluginId)
+        }
+
+        extensions.configure<KotlinMultiplatformExtension> {
+            androidTarget {
+                compilerOptions {
+                    jvmTarget.set(JvmTarget.JVM_17)
+                }
+            }
+
+            listOf(
+                iosX64(),
+                iosArm64(),
+                iosSimulatorArm64()
+            ).forEach {
+                it.binaries.framework {
+                    baseName = moduleName
+                    isStatic = true
+                    binaryOption("bundleId", moduleName)
+                }
+            }
+        }
+
+        extensions.configure<LibraryExtension> {
+            namespace = "io.github.rubenquadros.timetowish.$modulePackage"
+            compileSdk = libs.findVersion("android.compileSdk").get().requiredVersion.toInt()
+            defaultConfig {
+                minSdk = libs.findVersion("android.minSdk").get().requiredVersion.toInt()
+            }
+            compileOptions {
+                sourceCompatibility = JavaVersion.VERSION_17
+                targetCompatibility = JavaVersion.VERSION_17
+            }
+
+            buildTypes {
+                getByName("release") {
+                    isMinifyEnabled = false
+                    signingConfig = signingConfigs.findByName("release")
+                }
+
+                getByName("debug") {
+                    signingConfig = signingConfigs.getByName("debug")
+                }
+            }
+        }
+    }
+}

--- a/build-plugins/conventions/src/main/kotlin/io/github/rubenquadros/timetowish/conventions/Util.kt
+++ b/build-plugins/conventions/src/main/kotlin/io/github/rubenquadros/timetowish/conventions/Util.kt
@@ -1,0 +1,15 @@
+package io.github.rubenquadros.timetowish.conventions
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.VersionCatalogsExtension
+import org.gradle.kotlin.dsl.getByType
+
+internal fun Project.getCatalog() = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
+internal val Project.moduleName get() = path
+    .split(":").last { it.isNotBlank() }.lowercase()
+
+internal val Project.modulePackage get() = path
+    .split(":")
+    .filter { it.isNotBlank() }
+    .joinToString(".") { it.lowercase().replace("-", "") }

--- a/build-plugins/settings.gradle.kts
+++ b/build-plugins/settings.gradle.kts
@@ -1,0 +1,34 @@
+pluginManagement {
+    repositories {
+        google {
+            mavenContent {
+                includeGroupAndSubgroups("androidx")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+            }
+        }
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        google {
+            mavenContent {
+                includeGroupAndSubgroups("androidx")
+                includeGroupAndSubgroups("com.android")
+                includeGroupAndSubgroups("com.google")
+            }
+        }
+        mavenCentral()
+    }
+
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+include(":conventions")

--- a/features/home/build.gradle.kts
+++ b/features/home/build.gradle.kts
@@ -1,112 +1,17 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
-
 plugins {
-    alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.composeMultiplatform)
-    alias(libs.plugins.composeCompiler)
-    alias(libs.plugins.kotlinxSerialization)
-    alias(libs.plugins.ksp)
+    alias(libs.plugins.featureModule)
 }
 
 kotlin {
-    androidTarget {
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_17)
-        }
-    }
-
-    listOf(
-        iosX64(),
-        iosArm64(),
-        iosSimulatorArm64()
-    ).forEach {
-        it.binaries.framework {
-            baseName = "home"
-            isStatic = true
-            binaryOption("bundleId", "home")
-        }
-    }
-
     sourceSets {
-        androidMain.dependencies {
-            implementation(libs.bundles.androidx.compose)
-        }
-
         commonMain.dependencies {
-            implementation(compose.runtime)
-            implementation(compose.foundation)
-            implementation(compose.material3)
-            implementation(compose.ui)
-            implementation(compose.components.resources)
-            implementation(compose.components.uiToolingPreview)
-            implementation(libs.compose.navigation)
-            implementation(libs.compose.material.navigation)
-            implementation(libs.compose.lifecycle.viewmodel)
-
-            implementation(libs.bundles.ktor)
-
-            implementation(libs.koin.core)
-            implementation(libs.koin.annotations)
-            implementation(libs.koin.compose)
-            implementation(libs.koin.compose.viewmodel)
-            implementation(libs.koin.compose.viewmodel.navigation)
-            commonMain.configure { kotlin.srcDirs("build/generated/ksp/metadata/commonMain/kotlin") }
-
             implementation(libs.kotlinx.immutable.collections)
 
             implementation(libs.kotlinx.datetime)
-
-            //core
-            implementation(projects.foundation.core)
-            implementation(projects.foundation.designSystem)
-            implementation(projects.foundation.navigationRoutes)
-
-            //shared
-            implementation(projects.shared)
         }
     }
 }
 
 compose.resources {
     packageOfResClass = "io.github.rubenquadros.timetowish.feature.home.resources"
-}
-
-android {
-    namespace = "io.github.rubenquadros.timetowish.feature.home"
-    compileSdk = 35
-    defaultConfig {
-        minSdk = 26
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-}
-
-// KSP Tasks
-dependencies {
-    add("kspCommonMainMetadata", libs.koin.ksp.compiler)
-}
-
-// WORKAROUND: ADD this dependsOn("kspCommonMainKotlinMetadata") instead of above dependencies
-tasks.withType<KotlinCompilationTask<*>>().configureEach {
-    if (name != "kspCommonMainKotlinMetadata") {
-        dependsOn("kspCommonMainKotlinMetadata")
-    }
-}
-
-afterEvaluate {
-    tasks.filter {
-        it.name.contains("SourcesJar", true)
-    }.forEach {
-        it.dependsOn("kspCommonMainKotlinMetadata")
-    }
-}
-
-ksp {
-    arg("KOIN_CONFIG_CHECK","true")
-    arg("KOIN_DEFAULT_MODULE","false")
-    arg("KOIN_USE_COMPOSE_VIEWMODEL","true")
 }

--- a/features/login/build.gradle.kts
+++ b/features/login/build.gradle.kts
@@ -1,68 +1,16 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
-
 plugins {
-    alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.composeMultiplatform)
-    alias(libs.plugins.composeCompiler)
-    alias(libs.plugins.kotlinxSerialization)
-    alias(libs.plugins.ksp)
+    alias(libs.plugins.featureModule)
 }
 
 kotlin {
-    androidTarget {
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_17)
-        }
-    }
-
-    listOf(
-        iosX64(),
-        iosArm64(),
-        iosSimulatorArm64()
-    ).forEach {
-        it.binaries.framework {
-            baseName = "login"
-            isStatic = true
-        }
-    }
-
     sourceSets {
         androidMain.dependencies {
             implementation(libs.google.credentials)
             implementation(libs.google.credentials.id)
             implementation(libs.google.credentials.play.services)
-            implementation(libs.bundles.androidx.compose)
         }
 
         commonMain.dependencies {
-            implementation(compose.runtime)
-            implementation(compose.foundation)
-            implementation(compose.material3)
-            implementation(compose.ui)
-            implementation(compose.components.resources)
-            implementation(compose.components.uiToolingPreview)
-            implementation(libs.compose.navigation)
-            implementation(libs.compose.material.navigation)
-            implementation(libs.compose.lifecycle.viewmodel)
-
-            implementation(libs.bundles.ktor)
-
-            implementation(libs.koin.core)
-            implementation(libs.koin.annotations)
-            implementation(libs.koin.compose)
-            implementation(libs.koin.compose.viewmodel)
-            implementation(libs.koin.compose.viewmodel.navigation)
-            commonMain.configure { kotlin.srcDirs("build/generated/ksp/metadata/commonMain/kotlin") }
-
-            //core
-            implementation(projects.foundation.core)
-            implementation(projects.foundation.designSystem)
-            implementation(projects.foundation.navigationRoutes)
-
-            implementation(projects.shared)
-
             implementation(projects.services.auth)
         }
     }
@@ -70,53 +18,4 @@ kotlin {
 
 compose.resources {
     packageOfResClass = "io.github.rubenquadros.timetowish.feature.login.resources"
-}
-
-android {
-    namespace = "io.github.rubenquadros.timetowish.feature.login"
-    compileSdk = 35
-    defaultConfig {
-        minSdk = 26
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    buildTypes {
-        getByName("release") {
-            isMinifyEnabled = false
-            signingConfig = signingConfigs.findByName("release")
-        }
-
-        getByName("debug") {
-            signingConfig = signingConfigs.getByName("debug")
-        }
-    }
-}
-
-// KSP Tasks
-dependencies {
-    add("kspCommonMainMetadata", libs.koin.ksp.compiler)
-}
-
-// WORKAROUND: ADD this dependsOn("kspCommonMainKotlinMetadata") instead of above dependencies
-tasks.withType<KotlinCompilationTask<*>>().configureEach {
-    if (name != "kspCommonMainKotlinMetadata") {
-        dependsOn("kspCommonMainKotlinMetadata")
-    }
-}
-
-afterEvaluate {
-    tasks.filter {
-        it.name.contains("SourcesJar", true)
-    }.forEach {
-        it.dependsOn("kspCommonMainKotlinMetadata")
-    }
-}
-
-ksp {
-    arg("KOIN_CONFIG_CHECK","true")
-    arg("KOIN_DEFAULT_MODULE","false")
-    arg("KOIN_USE_COMPOSE_VIEWMODEL","true")
 }

--- a/foundation/core/build.gradle.kts
+++ b/foundation/core/build.gradle.kts
@@ -1,33 +1,11 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
-
 plugins {
-    alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.multiplatformModule)
+    alias(libs.plugins.kspModule)
+    alias(libs.plugins.dbModule)
     alias(libs.plugins.kotlinxSerialization)
-    alias(libs.plugins.ksp)
-    alias(libs.plugins.sqldelight)
 }
 
 kotlin {
-    androidTarget {
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_17)
-        }
-    }
-
-    listOf(
-        iosX64(),
-        iosArm64(),
-        iosSimulatorArm64()
-    ).forEach {
-        it.binaries.framework {
-            baseName = "core"
-            isStatic = true
-            binaryOption("bundleId", "core")
-        }
-    }
-
     sourceSets {
         commonMain.dependencies {
             implementation(libs.kotlinx.coroutines)
@@ -43,64 +21,13 @@ kotlin {
 
             implementation(libs.bundles.coil)
 
-            implementation(libs.sqldelight.coroutines)
-
             implementation(libs.kotlinx.immutable.collections)
         }
         androidMain.dependencies {
             implementation(libs.ktor.client.okhttp)
-            implementation(libs.sqldelight.android)
         }
         iosMain.dependencies {
             implementation(libs.ktor.client.darwin)
-            implementation(libs.sqldelight.ios)
-        }
-    }
-}
-
-// KSP Tasks
-dependencies {
-    add("kspCommonMainMetadata", libs.koin.ksp.compiler)
-}
-
-// WORKAROUND: ADD this dependsOn("kspCommonMainKotlinMetadata") instead of above dependencies
-tasks.withType<KotlinCompilationTask<*>>().configureEach {
-    if (name != "kspCommonMainKotlinMetadata") {
-        dependsOn("kspCommonMainKotlinMetadata")
-    }
-}
-
-afterEvaluate {
-    tasks.filter {
-        it.name.contains("SourcesJar", true)
-    }.forEach {
-        it.dependsOn("kspCommonMainKotlinMetadata")
-    }
-}
-
-ksp {
-    arg("KOIN_CONFIG_CHECK","true")
-    arg("KOIN_DEFAULT_MODULE","false")
-}
-
-android {
-    namespace = "io.github.rubenquadros.timetowish.core"
-    compileSdk = 35
-    defaultConfig {
-        minSdk = 26
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-}
-
-sqldelight {
-    databases {
-        create("TimeToWishDb") {
-            packageName.set("io.github.rubenquadros.timetowish.core")
-            schemaOutputDirectory.set(file("${rootProject.projectDir}/db-schema"))
-            generateAsync.set(true)
         }
     }
 }

--- a/foundation/design-system/build.gradle.kts
+++ b/foundation/design-system/build.gradle.kts
@@ -1,61 +1,17 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
-    alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.composeMultiplatform)
-    alias(libs.plugins.composeCompiler)
+    alias(libs.plugins.composeModule)
 }
 
 kotlin {
-    androidTarget {
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_17)
-        }
-    }
-
-    listOf(
-        iosX64(),
-        iosArm64(),
-        iosSimulatorArm64()
-    ).forEach {
-        it.binaries.framework {
-            baseName = "design-system"
-            isStatic = true
-        }
-    }
-
     sourceSets {
         commonMain.dependencies {
-            implementation(compose.runtime)
-            implementation(compose.foundation)
-            implementation(compose.material3)
-            implementation(compose.ui)
-            implementation(compose.components.resources)
-            implementation(compose.components.uiToolingPreview)
-
             implementation(libs.bundles.coil)
 
             implementation(libs.kotlinx.datetime)
-        }
-        androidMain.dependencies {
-            implementation(libs.bundles.androidx.compose)
         }
     }
 }
 
 compose.resources {
     packageOfResClass = "io.github.rubenquadros.timetowish.ui.resources"
-}
-
-android {
-    namespace = "io.github.rubenquadros.timetowish.ui"
-    compileSdk = 35
-    defaultConfig {
-        minSdk = 26
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
 }

--- a/foundation/navigation-routes/build.gradle.kts
+++ b/foundation/navigation-routes/build.gradle.kts
@@ -1,48 +1,14 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
-    alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.composeMultiplatform)
-    alias(libs.plugins.composeCompiler)
+    alias(libs.plugins.composeModule)
     alias(libs.plugins.kotlinxSerialization)
 }
 
 kotlin {
-    androidTarget {
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_17)
-        }
-    }
-
-    listOf(
-        iosX64(),
-        iosArm64(),
-        iosSimulatorArm64()
-    ).forEach {
-        it.binaries.framework {
-            baseName = "navigation-routes"
-            isStatic = true
-        }
-    }
-
     sourceSets {
         commonMain.dependencies {
             implementation(libs.compose.navigation)
             implementation(libs.compose.material.navigation)
             implementation(libs.kotlinx.serialization)
         }
-    }
-}
-
-android {
-    namespace = "io.github.rubenquadros.timetowish.navigation.routes"
-    compileSdk = 35
-    defaultConfig {
-        minSdk = 26
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,13 @@ google-credential = "1.5.0"
 google-id = "1.1.1"
 
 [libraries]
+#gradle plugins
+kotlin-gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+android-gradle = { module = "com.android.tools.build:gradle", version.ref = "agp" }
+compose-gradle = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "compose-multiplatform" }
+ksp-gradle = { module = "com.google.devtools.ksp:symbol-processing-gradle-plugin", version.ref = "ksp" }
+sqldelight-gradle = { module = "app.cash.sqldelight:gradle-plugin", version.ref = "sqldelight" }
+
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -118,3 +125,10 @@ kotlinCocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = 
 kotlinxSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinx-serialization-plugin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
+
+#Custom convention plugins
+multiplatformModule = { id = "io.github.rubenquadros.timetowish.multiplatform" }
+composeModule = { id = "io.github.rubenquadros.timetowish.compose" }
+kspModule = { id = "io.github.rubenquadros.timetowish.ksp" }
+dbModule = { id = "io.github.rubenquadros.timetowish.db" }
+featureModule = { id = "io.github.rubenquadros.timetowish.feature" }

--- a/scripts/basefiles/build.db.gradle.kts
+++ b/scripts/basefiles/build.db.gradle.kts
@@ -1,29 +1,9 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
-    alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.sqldelight)
+    alias(libs.plugins.featureModule)
+    alias(libs.plugins.dbModule)
 }
 
 kotlin {
-    androidTarget {
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_17)
-        }
-    }
-
-    listOf(
-        iosX64(),
-        iosArm64(),
-        iosSimulatorArm64()
-    ).forEach {
-        it.binaries.framework {
-            baseName = "moduleName"
-            isStatic = true
-        }
-    }
-
     sourceSets {
         commonMain.dependencies {
             //add your dependencies
@@ -36,26 +16,4 @@ kotlin {
 
 compose.resources {
     packageOfResClass = "modulePackage.resources"
-}
-
-android {
-    namespace = "modulePackage"
-    compileSdk = 35
-    defaultConfig {
-        minSdk = 26
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-}
-
-sqldelight {
-    databases {
-        create("TimeToWishDb") {
-            packageName.set("modulePackage")
-            schemaOutputDirectory.set(file("${rootProject.projectDir}/db-schema"))
-            generateAsync.set(true)
-        }
-    }
 }

--- a/scripts/basefiles/build.gradle.kts
+++ b/scripts/basefiles/build.gradle.kts
@@ -1,28 +1,8 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-
 plugins {
-    alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.androidLibrary)
+    alias(libs.plugins.featureModule)
 }
 
 kotlin {
-    androidTarget {
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_17)
-        }
-    }
-
-    listOf(
-        iosX64(),
-        iosArm64(),
-        iosSimulatorArm64()
-    ).forEach {
-        it.binaries.framework {
-            baseName = "moduleName"
-            isStatic = true
-        }
-    }
-
     sourceSets {
         commonMain.dependencies {
             //add your dependencies
@@ -35,16 +15,4 @@ kotlin {
 
 compose.resources {
     packageOfResClass = "modulePackage.resources"
-}
-
-android {
-    namespace = "modulePackage"
-    compileSdk = 35
-    defaultConfig {
-        minSdk = 26
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
 }

--- a/scripts/create_shared_module.sh
+++ b/scripts/create_shared_module.sh
@@ -87,7 +87,6 @@ if [ "$use_database" = "true" ]; then
 else
   cp "$base_path"/build.gradle.kts "$module_dir"/build.gradle.kts
 fi
-sed -i '' "s|moduleName|$module_name|g" build.gradle.kts
 sed -i '' "s|modulePackage|$package_name|g" build.gradle.kts
 
 #create commonMain and commonTest

--- a/services/auth/build.gradle.kts
+++ b/services/auth/build.gradle.kts
@@ -1,31 +1,10 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
-
 plugins {
-    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.multiplatformModule)
     alias(libs.plugins.kotlinCocoapods)
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.ksp)
+    alias(libs.plugins.kspModule)
 }
 
 kotlin {
-    androidTarget {
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_17)
-        }
-    }
-
-    listOf(
-        iosX64(),
-        iosArm64(),
-        iosSimulatorArm64()
-    ).forEach {
-        it.binaries.framework {
-            baseName = "auth"
-            isStatic = true
-        }
-    }
-
     cocoapods {
         summary = "This is the auth module"
         homepage = "Link to the Auth Module homepage"
@@ -58,42 +37,5 @@ kotlin {
             //core
             implementation(projects.foundation.core)
         }
-    }
-}
-
-// KSP Tasks
-dependencies {
-    add("kspCommonMainMetadata", libs.koin.ksp.compiler)
-}
-
-// WORKAROUND: ADD this dependsOn("kspCommonMainKotlinMetadata") instead of above dependencies
-tasks.withType<KotlinCompilationTask<*>>().configureEach {
-    if (name != "kspCommonMainKotlinMetadata") {
-        dependsOn("kspCommonMainKotlinMetadata")
-    }
-}
-
-afterEvaluate {
-    tasks.filter {
-        it.name.contains("SourcesJar", true)
-    }.forEach {
-        it.dependsOn("kspCommonMainKotlinMetadata")
-    }
-}
-
-ksp {
-    arg("KOIN_CONFIG_CHECK","true")
-    arg("KOIN_DEFAULT_MODULE","false")
-}
-
-android {
-    namespace = "io.github.rubenquadros.timetowish.services.auth"
-    compileSdk = 35
-    defaultConfig {
-        minSdk = 26
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,6 +28,7 @@ dependencyResolutionManagement {
     }
 }
 
+includeBuild("build-plugins")
 include(":composeApp")
 include(":foundation:design-system")
 include(":foundation:core")

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -1,105 +1,25 @@
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
-
 plugins {
-    alias(libs.plugins.kotlinMultiplatform)
-    alias(libs.plugins.androidLibrary)
-    alias(libs.plugins.composeMultiplatform)
-    alias(libs.plugins.composeCompiler)
-    alias(libs.plugins.ksp)
-    alias(libs.plugins.sqldelight)
+    alias(libs.plugins.composeModule)
+    alias(libs.plugins.kspModule)
+    alias(libs.plugins.dbModule)
 }
 
 kotlin {
-    androidTarget {
-        compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_17)
-        }
-    }
-
-    listOf(
-        iosX64(),
-        iosArm64(),
-        iosSimulatorArm64()
-    ).forEach {
-        it.binaries.framework {
-            baseName = "shared"
-            isStatic = true
-        }
-    }
-
     sourceSets {
         androidMain.dependencies {
-            implementation(libs.bundles.androidx.compose)
             implementation(libs.androidx.core.ktx)
             implementation(libs.androidx.browser)
         }
 
         commonMain.dependencies {
-            implementation(compose.runtime)
-            implementation(compose.foundation)
-            implementation(compose.material3)
-            implementation(compose.ui)
-            implementation(compose.components.resources)
-            implementation(compose.components.uiToolingPreview)
-
             implementation(libs.koin.core)
             implementation(libs.koin.annotations)
             commonMain.configure { kotlin.srcDirs("build/generated/ksp/metadata/commonMain/kotlin") }
-
-            implementation(libs.sqldelight.coroutines)
 
             implementation(libs.kotlinx.datetime)
 
             implementation(projects.foundation.core)
             implementation(projects.foundation.designSystem)
-        }
-    }
-}
-
-android {
-    namespace = "io.github.rubenquadros.timetowish.shared"
-    compileSdk = 35
-    defaultConfig {
-        minSdk = 26
-    }
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-}
-
-// KSP Tasks
-dependencies {
-    add("kspCommonMainMetadata", libs.koin.ksp.compiler)
-}
-
-// WORKAROUND: ADD this dependsOn("kspCommonMainKotlinMetadata") instead of above dependencies
-tasks.withType<KotlinCompilationTask<*>>().configureEach {
-    if (name != "kspCommonMainKotlinMetadata") {
-        dependsOn("kspCommonMainKotlinMetadata")
-    }
-}
-
-afterEvaluate {
-    tasks.filter {
-        it.name.contains("SourcesJar", true)
-    }.forEach {
-        it.dependsOn("kspCommonMainKotlinMetadata")
-    }
-}
-
-ksp {
-    arg("KOIN_CONFIG_CHECK","true")
-    arg("KOIN_DEFAULT_MODULE","false")
-}
-
-sqldelight {
-    databases {
-        create("TimeToWishDb") {
-            packageName.set("io.github.rubenquadros.timetowish.shared")
-            schemaOutputDirectory.set(file("${rootProject.projectDir}/db-schema"))
-            generateAsync.set(true)
         }
     }
 }


### PR DESCRIPTION
To simplify dependency management and reduce the boilerplate code, the following gradle plugins are created:

- Multiplatform plugin: This adds multiplatform support for android and ios targets
- Compose plugin: This adds compose multiplatform support (This includes multiplatform plugin)
- Ksp plugin: This adds ksp support (mainly for koin)
- Database plugin: This adds sqldelight support
- Feature plugin: This adds minimum required dependencies for a feature. This includes compose and ksp plugins.

The module creating script is also modified to support these changes.